### PR TITLE
Adds :quote_char option

### DIFF
--- a/ext/rcsv/rcsv.c
+++ b/ext/rcsv/rcsv.c
@@ -110,7 +110,7 @@ void end_of_field_callback(void * field, size_t field_size, void * data) {
       if (meta->current_col < meta->num_row_conversions) {
         switch (row_conversion){
           case 's': /* String */
-            parsed_field = ENCODED_STR_NEW(field_str, field_size, meta->encoding_index); 
+            parsed_field = ENCODED_STR_NEW(field_str, field_size, meta->encoding_index);
             break;
           case 'i': /* Integer */
             parsed_field = LL2NUM(atoll(field_str));
@@ -327,6 +327,12 @@ VALUE rcsv_raw_parse(VALUE ensure_container) {
     csv_set_delim(cp, (unsigned char)*StringValuePtr(option));
   }
 
+  /* :quote_char sets the character used for quoting data; default is double-quote (") */
+  option = rb_hash_aref(options, ID2SYM(rb_intern("quote_char")));
+  if (option != Qnil) {
+    csv_set_quote(cp, (unsigned char)*StringValuePtr(option));
+  }
+
   /* Specify how many rows to skip from the beginning of CSV */
   option = rb_hash_aref(options, ID2SYM(rb_intern("offset_rows")));
   if (option != Qnil) {
@@ -382,7 +388,7 @@ VALUE rcsv_raw_parse(VALUE ensure_container) {
 
   /* :row_conversions specifies Ruby types that CSV field values should be converted into.
      Each char of row_conversions string represents Ruby type for CSV field with matching position. */
-  option = rb_hash_aref(options, ID2SYM(rb_intern("row_conversions"))); 
+  option = rb_hash_aref(options, ID2SYM(rb_intern("row_conversions")));
   if (option != Qnil) {
     meta->num_row_conversions = RSTRING_LEN(option);
     meta->row_conversions = StringValuePtr(option);
@@ -390,7 +396,7 @@ VALUE rcsv_raw_parse(VALUE ensure_container) {
 
  /* Column names should be declared explicitly when parsing fields as Hashes */
   if (meta->row_as_hash) { /* Only matters for hash results */
-    option = rb_hash_aref(options, ID2SYM(rb_intern("column_names"))); 
+    option = rb_hash_aref(options, ID2SYM(rb_intern("column_names")));
     if (option == Qnil) {
       rb_raise(rcsv_parse_error, ":row_as_hash requires :column_names to be set.");
     } else {

--- a/lib/lib_csv.rb
+++ b/lib/lib_csv.rb
@@ -34,6 +34,9 @@ class LibCsv
   attach_function :csv_set_delim, [:pointer, :uchar], :void
   attach_function :csv_get_delim, [:pointer], :uchar
 
+  attach_function :csv_set_quote, [:pointer, :uchar], :void
+  attach_function :csv_get_quote, [:pointer], :uchar
+
   attach_function :csv_error, [:pointer], :int
   attach_function :csv_strerror, [:int], :string
 
@@ -44,6 +47,10 @@ class LibCsv
 
     if options[:col_sep]
       csv_set_delim(parser, options[:col_sep].ord)
+    end
+
+    if options[:quote_char]
+      csv_set_quote(parser, options[:quote_char].ord)
     end
 
     fail "Couldn't initialize libcsv" if result == -1
@@ -82,7 +89,7 @@ class LibCsv
     csv_fini(parser, end_of_field_callback, end_of_record_callback, nil)
     csv_free(parser)
     result.pop if result.last == []
-    
+
     return result
   end
 end

--- a/lib/rcsv.rb
+++ b/lib/rcsv.rb
@@ -30,6 +30,7 @@ class Rcsv
     raw_options = {}
 
     raw_options[:col_sep] = options[:column_separator] && options[:column_separator][0] || ','
+    raw_options[:quote_char] = options[:quote_char] && options[:quote_char][0] || '"'
     raw_options[:offset_rows] = options[:offset_rows] || 0
     raw_options[:nostrict] = options[:nostrict]
     raw_options[:parse_empty_fields_as] = options[:parse_empty_fields_as]

--- a/test/test_rcsv_raw_parse.rb
+++ b/test/test_rcsv_raw_parse.rb
@@ -32,17 +32,29 @@ class RcsvRawParseTest < Test::Unit::TestCase
     assert_equal('""C81E-=; **ECCB; .. 89', raw_parsed_tsv_data[3][6])
     assert_equal("Dallas\t TX", raw_parsed_tsv_data[888][13])
   end
-  
+
+  def test_rcsv_quote_char
+    csv = [
+      "F0A83489,69118080,,73,7008,2016-10-03,'''''C81E-=; **ECCB; .. 89','130,86',a3eb,1341-04-10,7612.699237971538,5b5e3fce-2ea5-4ca9-9749-90fd6dc8dd66,9,'Los Angeles, CA',e,6.047887837492023,f",
+      "48F4FAC9,11599213,,0,1897,2014-02-23,'''''ECCB-=; **A87F; .. 61','787,6',84de,1353-11-10,8078.704911344607,404d9d3e-963f-4199-a2f3-e71f6828b716,6,'Dallas, TX',,-6.684507609859605, 1"
+    ]
+    csv_data = StringIO.new(csv.join("\n"))
+    raw_parsed_csv_data = Rcsv.raw_parse(csv_data, :quote_char => "'")
+
+    assert_equal("''C81E-=; **ECCB; .. 89", raw_parsed_csv_data[0][6])
+    assert_equal('Dallas, TX', raw_parsed_csv_data[1][13])
+  end
+
   if String.instance_methods.include?(:encoding)
     def test_rcsv_output_encoding_default
       raw_parsed_csv_data = Rcsv.raw_parse(@csv_data)
-    
+
       assert_equal(raw_parsed_csv_data[0][2].encoding, Encoding::ASCII_8BIT)
     end
 
     def test_rcsv_output_encoding_utf8
       raw_parsed_csv_data = Rcsv.raw_parse(@csv_data, :output_encoding => "UTF-8")
-      
+
       assert_equal(raw_parsed_csv_data[0][2].encoding, Encoding::UTF_8)
     end
   else
@@ -52,7 +64,7 @@ class RcsvRawParseTest < Test::Unit::TestCase
       end
     end
   end
-    
+
   def test_buffer_size
     raw_parsed_csv_data = Rcsv.raw_parse(@csv_data, :buffer_size => 10)
 


### PR DESCRIPTION
This exposes to Ruby the functionality provided by the `csv_set_quote` function in libcsv.

I just noticed the whitespace changes; this is something my text editor is configured to do. If you'd prefer that I remove those lines from the diff, just say so.

Also, if you want more tests, I'm happy to provide them.
