### PR TITLE
Writer fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,5 @@
 language: ruby
 rvm:
   - 1.9.3
-  - 1.9.2
-  - 2.0.0
-  - 2.1.0
-  - 1.8.7
-  - ree
-env:
-  - JRUBY_OPTS="--server -Xcext.enabled=true -Xcompile.invokedynamic=false"
+  - 2.0
+  - 2.1

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://travis-ci.org/fiksu/rcsv.png)](https://travis-ci.org/fiksu/rcsv)
 
-Rcsv is a fast CSV parsing library for MRI Ruby. Tested on REE 1.8.7 and Ruby 1.9.3.
+Rcsv is a fast CSV parsing library for MRI Ruby. Tested on Ruby 1.9.3, 2.0, and 2.1.
 
 Contrary to many other gems that implement their own parsers, Rcsv uses libcsv 3.0.3 (http://sourceforge.net/projects/libcsv/). As long as libcsv's API is stable, getting Rcsv to use newer libcsv version is as simple as updating two files (csv.h and libcsv.c).
 

--- a/lib/rcsv.rb
+++ b/lib/rcsv.rb
@@ -140,6 +140,14 @@ class Rcsv
     @write_options[:column_separator] ||= ','
     @write_options[:newline_delimiter] ||= "\r\n" # Making Excel happy...
     @write_options[:header] ||= false
+
+    @quote = '"'
+    @escaped_quote = @quote * 2
+    @quotable_chars = Regexp.new('[%s%s%s]' % [
+      Regexp.escape(@write_options[:column_separator]),
+      Regexp.escape(@write_options[:newline_delimiter]),
+      Regexp.escape(@quote)
+    ])
   end
 
   def write(io, &block)
@@ -162,8 +170,7 @@ class Rcsv
 
     row.each_with_index do |field, index|
       unquoted_field = process(field, @write_options[:columns] && @write_options[:columns][index])
-      # TODO: a better quoting
-      csv_row << (unquoted_field.match(/,/) ? "\"#{unquoted_field}\"" : unquoted_field)
+      csv_row << (unquoted_field.match(@quotable_chars) ? "\"#{unquoted_field.gsub(@quote, @escaped_quote)}\"" : unquoted_field)
       csv_row << column_separator unless index == max_index
     end
 

--- a/lib/rcsv.rb
+++ b/lib/rcsv.rb
@@ -161,7 +161,7 @@ class Rcsv
     max_index = row.size - 1
 
     row.each_with_index do |field, index|
-      unquoted_field = process(field, @write_options[:columns][index])
+      unquoted_field = process(field, @write_options[:columns] && @write_options[:columns][index])
       # TODO: a better quoting
       csv_row << (unquoted_field.match(/,/) ? "\"#{unquoted_field}\"" : unquoted_field)
       csv_row << column_separator unless index == max_index
@@ -173,7 +173,7 @@ class Rcsv
   protected
 
   def process(field, column_options)
-    return case column_options[:formatter]
+    return case column_options && column_options[:formatter]
     when :strftime
       format = column_options[:format] || "%Y-%m-%d %H:%M:%S %z"
       field.strftime(format)

--- a/lib/rcsv.rb
+++ b/lib/rcsv.rb
@@ -2,6 +2,7 @@ require "rcsv/rcsv"
 require "rcsv/version"
 
 require "stringio"
+require "English"
 
 class Rcsv
 
@@ -138,7 +139,7 @@ class Rcsv
   def initialize(write_options = {})
     @write_options = write_options
     @write_options[:column_separator] ||= ','
-    @write_options[:newline_delimiter] ||= "\r\n" # Making Excel happy...
+    @write_options[:newline_delimiter] ||= $INPUT_RECORD_SEPARATOR
     @write_options[:header] ||= false
 
     @quote = '"'

--- a/test/test_rcsv_write.rb
+++ b/test/test_rcsv_write.rb
@@ -57,12 +57,12 @@ class RcsvWriteTest < Test::Unit::TestCase
 
   def test_rcsv_generate_header
     assert_equal(
-      "ID,Date,Money,Banana IDDQD,Hashformat,\r\n", @writer.generate_header
+      "ID,Date,Money,Banana IDDQD,Hashformat,\n", @writer.generate_header
     )
   end
 
   def test_rscv_generate_row
-    assert_equal("1,2012-11-11,$100.23,true,$1.00,false\r\n", @writer.generate_row(@data.first))
+    assert_equal("1,2012-11-11,$100.23,true,$1.00,false\n", @writer.generate_row(@data.first))
   end
 
   def test_rcsv_write
@@ -75,7 +75,7 @@ class RcsvWriteTest < Test::Unit::TestCase
     io.rewind
 
     assert_equal(
-      "ID,Date,Money,Banana IDDQD,Hashformat,\r\n1,2012-11-11,$100.23,true,$1.00,false\r\n,1970-01-02,$-0.10,nyancat,$123.89,false\r\n3,2012-12-12,$0.00,sepulka,$-122.00,true\r\n", io.read
+      "ID,Date,Money,Banana IDDQD,Hashformat,\n1,2012-11-11,$100.23,true,$1.00,false\n,1970-01-02,$-0.10,nyancat,$123.89,false\n3,2012-12-12,$0.00,sepulka,$-122.00,true\n", io.read
     )
   end
 
@@ -90,18 +90,18 @@ class RcsvWriteTest < Test::Unit::TestCase
     io.rewind
 
     assert_equal(
-      "1,2012-11-11,$100.23,true,$1.00,false\r\n,1970-01-02,$-0.10,nyancat,$123.89,false\r\n3,2012-12-12,$0.00,sepulka,$-122.00,true\r\n", io.read
+      "1,2012-11-11,$100.23,true,$1.00,false\n,1970-01-02,$-0.10,nyancat,$123.89,false\n3,2012-12-12,$0.00,sepulka,$-122.00,true\n", io.read
     )
   end
 
   def test_generate_row__dont_require_columns
     writer = Rcsv.new
-    assert_equal "1,2,3\r\n", writer.generate_row([1, 2, 3])
+    assert_equal "1,2,3\n", writer.generate_row([1, 2, 3])
   end
 
   def test_generate_row__proper_escaping_for_quotes_and_newlines
     writer = Rcsv.new
-    assert_equal "\"before quote \"\" after quote\",\"before newline \n after newline\"\r\n",
+    assert_equal "\"before quote \"\" after quote\",\"before newline \n after newline\"\n",
                  writer.generate_row(["before quote \" after quote", "before newline \n after newline"])
   end
 
@@ -118,6 +118,6 @@ class RcsvWriteTest < Test::Unit::TestCase
 
   def test_generate_row__should_handle_alternate_column_separators
     writer = Rcsv.new(column_separator: '|')
-    assert_equal "1|2|\"before pipe | after pipe\"\r\n", writer.generate_row([1, 2, 'before pipe | after pipe'])
+    assert_equal "1|2|\"before pipe | after pipe\"\n", writer.generate_row([1, 2, 'before pipe | after pipe'])
   end
 end

--- a/test/test_rcsv_write.rb
+++ b/test/test_rcsv_write.rb
@@ -93,4 +93,9 @@ class RcsvWriteTest < Test::Unit::TestCase
       "1,2012-11-11,$100.23,true,$1.00,false\r\n,1970-01-02,$-0.10,nyancat,$123.89,false\r\n3,2012-12-12,$0.00,sepulka,$-122.00,true\r\n", io.read
     )
   end
+
+  def test_dont_require_columns
+    writer = Rcsv.new
+    assert_equal "1,2,3\r\n", writer.generate_row([1,2,3])
+  end
 end

--- a/test/test_rcsv_write.rb
+++ b/test/test_rcsv_write.rb
@@ -94,8 +94,30 @@ class RcsvWriteTest < Test::Unit::TestCase
     )
   end
 
-  def test_dont_require_columns
+  def test_generate_row__dont_require_columns
     writer = Rcsv.new
-    assert_equal "1,2,3\r\n", writer.generate_row([1,2,3])
+    assert_equal "1,2,3\r\n", writer.generate_row([1, 2, 3])
+  end
+
+  def test_generate_row__proper_escaping_for_quotes_and_newlines
+    writer = Rcsv.new
+    assert_equal "\"before quote \"\" after quote\",\"before newline \n after newline\"\r\n",
+                 writer.generate_row(["before quote \" after quote", "before newline \n after newline"])
+  end
+
+  def test_generate_row__should_be_able_to_parse_generated_csv
+    writer = Rcsv.new
+    quotable_strings = [
+      "before quote \" after quote",
+      "before newline \n after newline",
+      "before separator , after separator",
+      "separator , and quote \" oh my"
+    ]
+    assert_equal [quotable_strings], Rcsv.parse(writer.generate_row(quotable_strings), header: :none)
+  end
+
+  def test_generate_row__should_handle_alternate_column_separators
+    writer = Rcsv.new(column_separator: '|')
+    assert_equal "1|2|\"before pipe | after pipe\"\r\n", writer.generate_row([1, 2, 'before pipe | after pipe'])
   end
 end


### PR DESCRIPTION
Changed the way quoting works to be more standard. There is a performance hit, but it seemed a worthwhile tradeoff for correctness. Also changed the default line separator to be the system standard rather than \r\n.

If you want me to remove the ruby support commit out I can, but I don't think there is much value in supporting <1.9.