### PR TITLE
Adding support for offset_rows with header

### DIFF
--- a/lib/rcsv.rb
+++ b/lib/rcsv.rb
@@ -53,10 +53,10 @@ class Rcsv
     case options[:header]
     when :use
       header = self.raw_parse(StringIO.new(csv_data.each_line.first), raw_options).first
-      raw_options[:offset_rows] = options[:offset_rows] || 1
+      raw_options[:offset_rows] = corrected_offset_rows(options[:offset_rows])
     when :skip
       header = (0..(csv_data.each_line.first.split(raw_options[:col_sep]).count)).to_a
-      raw_options[:offset_rows] = options[:offset_rows] || 1
+      raw_options[:offset_rows] = corrected_offset_rows(options[:offset_rows])
     when :none
       header = (0..(csv_data.each_line.first.split(raw_options[:col_sep]).count)).to_a
     end
@@ -196,5 +196,13 @@ class Rcsv
     else
       field.to_s
     end
+  end
+
+  private
+
+  def self.corrected_offset_rows(offset_rows)
+    return 1 if offset_rows.nil? || offset_rows <= 0
+
+    offset_rows
   end
 end

--- a/lib/rcsv.rb
+++ b/lib/rcsv.rb
@@ -32,7 +32,7 @@ class Rcsv
 
     raw_options[:col_sep] = options[:column_separator] && options[:column_separator][0] || ','
     raw_options[:quote_char] = options[:quote_char] && options[:quote_char][0] || '"'
-    raw_options[:offset_rows] = options[:offset_rows] || 0
+    raw_options[:offset_rows] = 0
     raw_options[:nostrict] = options[:nostrict]
     raw_options[:parse_empty_fields_as] = options[:parse_empty_fields_as]
     raw_options[:buffer_size] = options[:buffer_size] || 1024 * 1024 # 1 MiB
@@ -53,10 +53,10 @@ class Rcsv
     case options[:header]
     when :use
       header = self.raw_parse(StringIO.new(csv_data.each_line.first), raw_options).first
-      raw_options[:offset_rows] += 1
+      raw_options[:offset_rows] = options[:offset_rows] || 1
     when :skip
       header = (0..(csv_data.each_line.first.split(raw_options[:col_sep]).count)).to_a
-      raw_options[:offset_rows] += 1
+      raw_options[:offset_rows] = options[:offset_rows] || 1
     when :none
       header = (0..(csv_data.each_line.first.split(raw_options[:col_sep]).count)).to_a
     end

--- a/test/test_rcsv_parse.rb
+++ b/test/test_rcsv_parse.rb
@@ -69,6 +69,34 @@ class RcsvParseTest < Test::Unit::TestCase
     }, parsed_data.first)
   end
 
+  def test_rcsv_parse_with_offset_zero
+    csv = "a,b,c,d,e,f\n1,2,3,4,5,161226289488"
+    parsed_data = Rcsv.parse(csv,
+      :row_as_hash => true,
+      :offset_rows => 0,
+      :columns => {
+        'b' => {
+          :type => :int,
+        },
+        'd' => {
+          :type => :int
+        },
+        'f' => {
+          :type => :int
+        }
+      }
+    )
+
+    assert_equal({
+      'a' => '1',
+      'b' => 2,
+      'c' => '3',
+      'd' => 4,
+      'e' => '5',
+      'f' => 161226289488,
+    }, parsed_data.first)
+  end
+
   def test_rcsv_parse_only_rows
     csv = "a,1,t\nb,2,false\nc,3,0"
     parsed_data = Rcsv.parse(csv,

--- a/test/test_rcsv_parse.rb
+++ b/test/test_rcsv_parse.rb
@@ -41,6 +41,34 @@ class RcsvParseTest < Test::Unit::TestCase
     }, parsed_data.first)
   end
 
+  def test_rcsv_parse_with_offset
+    csv = "a,b,c,d,e,f\n1,2,3,4,5,161226289488\n6,7,8,9,10,161226289488"
+    parsed_data = Rcsv.parse(csv,
+      :row_as_hash => true,
+      :offset_rows => 2,
+      :columns => {
+        'b' => {
+          :type => :int,
+        },
+        'd' => {
+          :type => :int
+        },
+        'f' => {
+          :type => :int
+        }
+      }
+    )
+
+    assert_equal({
+      'a' => '6',
+      'b' => 7,
+      'c' => '8',
+      'd' => 9,
+      'e' => '10',
+      'f' => 161226289488,
+    }, parsed_data.first)
+  end
+
   def test_rcsv_parse_only_rows
     csv = "a,1,t\nb,2,false\nc,3,0"
     parsed_data = Rcsv.parse(csv,


### PR DESCRIPTION
I was running into a bug where if I passed in a csv with a header, passed in my columns, and then passed in an offset_row > 0, I would get `!! #<NoMethodError: undefined method 'each' for nil:NilClass>` when trying to parse. My need for this was to parse a csv in chunks - make 1000 objects, save them, take another thousand, etc.

The problem seems to be that when the header is set, it uses `raw_options[:offset_rows]`, which if not given or is 0, it works (header is at 0). If given, it was being set to `options[:offset_rows]`, and then header would fail.

The fix here is to set it to 0 initially, and then either set it to what was given by the user, or 1 if none was given (to make up for the previous `+= 1`, where it assumed `:offset_rows` was 0).

All tests are passing for me, and I added two new ones for the code I changed. Let me know if there is anything else I can do here, or if I misunderstood something.
