### PR TITLE
Handle parsing an empty file.

### DIFF
--- a/lib/rcsv.rb
+++ b/lib/rcsv.rb
@@ -50,15 +50,18 @@ class Rcsv
 
     initial_position = csv_data.pos
 
+    first_line = csv_data.each_line.first
+    return [] if first_line.nil?
+
     case options[:header]
     when :use
-      header = self.raw_parse(StringIO.new(csv_data.each_line.first), raw_options).first
+      header = self.raw_parse(StringIO.new(first_line), raw_options).first
       raw_options[:offset_rows] += 1
     when :skip
-      header = (0..(csv_data.each_line.first.split(raw_options[:col_sep]).count)).to_a
+      header = (0..(first_line.split(raw_options[:col_sep]).count)).to_a
       raw_options[:offset_rows] += 1
     when :none
-      header = (0..(csv_data.each_line.first.split(raw_options[:col_sep]).count)).to_a
+      header = (0..(first_line.split(raw_options[:col_sep]).count)).to_a
     end
 
     raw_options[:row_as_hash] = options[:row_as_hash] # Setting after header parsing

--- a/test/test_rcsv_parse.rb
+++ b/test/test_rcsv_parse.rb
@@ -13,6 +13,10 @@ class RcsvParseTest < Test::Unit::TestCase
     }
   end
 
+  def test_rcsv_parse_empty
+    assert_equal [], Rcsv.parse('')
+  end
+
   def test_rcsv_parse_unknown_rows
     csv = "a,b,c,d,e,f\n1,2,3,4,5,161226289488"
     parsed_data = Rcsv.parse(csv,


### PR DESCRIPTION
Fixes an error (one of several, depending on the `header` option used), when parsing an empty file:

```
irb(main):007:0> open('tmp.csv') { |f| Rcsv.parse(f, header: :none) }
NoMethodError: undefined method `split' for nil:NilClass
	from /Users/g/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/rcsv-0.3.1/lib/rcsv.rb:61:in `parse'
	from (irb):7:in `block in irb_binding'
	from (irb):7:in `open'
	from (irb):7
	from /Users/g/.rbenv/versions/2.2.2/bin/irb:11:in `<main>'
```
